### PR TITLE
Adds a new dependency to test fips specific revision importing feature.

### DIFF
--- a/fips.yml
+++ b/fips.yml
@@ -5,7 +5,6 @@
 imports:
     fips-hello-dep1:
         git:    https://github.com/floooh/fips-hello-dep1.git
-
-
-
-
+    fips-hello-dep3:
+        git:    https://github.com/fungos/fips-hello-dep3.git
+        rev:    191f59f0

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
 fips_begin_app(hello cmdline)
     fips_files(hello.cc)
-    fips_deps(dep1)
+    fips_deps(dep1 dep3)
 fips_end_app()

--- a/src/hello.cc
+++ b/src/hello.cc
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include "dep1/dep1.h"
+#include "dep3/dep3.h"
 
 #if FIPS_PNACL | FIPS_IOS | FIPS_ANDROID
 #error "Standard C Hello World not supported on this platform"
@@ -16,6 +17,9 @@ int main(int argc, const char** argv) {
     for (int i = 0; i < argc; i++) {
         printf("Arg %d: %s\n", i, argv[i]);
     }
+
+    correct_old_api_dep3(1);
+
     return 0;
 }
 


### PR DESCRIPTION
The new dependency emulates an API change in a project in progress that may
break projects that depends on it. This project depends on a specific
version of the dep3 project, the project in question does not uses tagging,
so the only way to reference the good version is by using a commit SHA1-ref.

This commit will break fips testing as it needs support to the revision import in fips.
This projects is in a _broken_ state intentionally so we can test pinpointing a commit.

PS. This uses a third project https://github.com/fungos/fips-hello-dep3 that I will transfer ownership to you if this structure works for you, this will require fixing the import entry in the fips.yml to point to your url afterwards.
PS2. sorry about missing the branch, I will get used to it.
